### PR TITLE
添加变形事件

### DIFF
--- a/COG/Listener/IListener.cs
+++ b/COG/Listener/IListener.cs
@@ -214,6 +214,29 @@ public interface IListener
         return true;
     }
 
+    /// <summary>
+    ///     当一个玩家向房主发送变形请求的时候，触发该监听器
+    /// </summary>
+    /// <param name="player">发出变形请求的玩家</param>
+    /// <param name="target">变形的目标</param>
+    /// <param name="shouldAnimate">是否显示变形动画</param>
+    /// <returns>是否取消事件[false为取消]</returns>
+    ///     如果通过return false取消本次请求，应该向player发出RejectShapeshift
+    bool OnCheckShapeshift(PlayerControl player, PlayerControl target, bool shouldAnimate)
+    {
+        return true;
+    }
+
+    /// <summary>
+    ///     当变形请求被执行时，触发该监听器
+    /// </summary>
+    /// <param name="player">变形者</param>
+    /// <param name="target">变形的目标</param>
+    /// <param name="shouldAnimate">是否显示变形动画</param>
+    void OnShapeshift(PlayerControl player, PlayerControl target, bool shouldAnimate)
+    {
+    }
+
     void AfterRPCReceived(byte callId, MessageReader reader)
     {
     }


### PR DESCRIPTION
通过onCheckShapeshift，房主可以决定是否取消玩家的变形操作
通过onShapeshift, 房主和客户端可以执行与变形相关的代码

前者可能节省不必要的变形动画 (例如在H系中 骇客使用变形按钮骇入玩家)
后者是在房主同意并发送变形操作后 房主和客户同时执行的操作

我并不是很确定如何写cog框架的listener事件，参考已有的代码进行cv添加操作，希望不会产生屎山
想请教一下添加listener的规范，如果可以我打算把MeetingHud和ShipStatus给做了，如果有任何错漏之处请指正